### PR TITLE
Bump plugin.yaml version to 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ Next download and install the registry plugin for Helm.
 ### OSX
 
 ```
-wget https://github.com/app-registry/helm-plugin/releases/download/v0.3.7/registry-helm-plugin-v0.3.7-dev-osx-x64.tar.gz
+wget https://github.com/app-registry/helm-plugin/releases/download/v0.4.0/registry-helm-plugin-v0.4.0-dev-osx-x64.tar.gz
 mkdir -p ~/.helm/plugins/
-tar xzvf registry-helm-plugin-v0.3.7-dev-osx-x64.tar.gz -C ~/.helm/plugins/
+tar xzvf registry-helm-plugin-v0.4.0-dev-osx-x64.tar.gz -C ~/.helm/plugins/
 ```
 
 ### Linux
 
 ```
-wget https://github.com/app-registry/helm-plugin/releases/download/v0.3.7/registry-helm-plugin-v0.3.7-dev-linux-x64.tar.gz
+wget https://github.com/app-registry/helm-plugin/releases/download/v0.4.0/registry-helm-plugin-v0.4.0-dev-linux-x64.tar.gz
 mkdir -p ~/.helm/plugins/
-tar xzvf registry-helm-plugin-v0.3.7-dev-linux-x64.tar.gz -C ~/.helm/plugins/
+tar xzvf registry-helm-plugin-v0.4.0-dev-linux-x64.tar.gz -C ~/.helm/plugins/
 ```
 
 ## Deploy Jenkins Using Helm from the Quay Registry

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "registry"
-version: "0.3.8"
+version: "0.4.0"
 usage: "Integrate CNR client to HELM"
 description: |-
   This plugin provides CNR client to Helm.


### PR DESCRIPTION
It looks like the 0.4.0 release tarball has the wrong version number in plugin.yaml, making my `helm plugin list` command confusingly show the wrong number.

This PR corrects that, but you'd need to re-tag and re-release to fix. Or cut a 0.4.1.