### PR TITLE
Use TLS1.2 when connecting to github.com using HTTPS

### DIFF
--- a/cnr.ps1
+++ b/cnr.ps1
@@ -12,6 +12,7 @@ function List_Plugin_Versions() {
     if ($Env:HTTPS_PROXY) {
         $Params.add('Proxy', $Env:HTTPS_PROXY)
     }
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     return Invoke-WebRequest @Params | ConvertFrom-Json
 
 }


### PR DESCRIPTION
Github has removed support for TLS1.0, which is the default when using
"Invoke-WebRequest". Therefore connections to github using HTTPS fail
with error: Could not create SSL/TLS secure channel.

See: https://githubengineering.com/crypto-removal-notice/