### PR TITLE
Plugin manager support

### DIFF
--- a/cnr.sh
+++ b/cnr.sh
@@ -42,15 +42,17 @@ function download_appr {
 function download_or_noop {
   if [ ! -e "$HELM_PLUGIN_DIR/appr" ]; then
     echo "Registry plugin assets do not exist, download them now !"
-    download_appr $1
+    download_appr
   fi
 }
 
 [ -z "$HELM_PLUGIN_DIR" ] && HELM_PLUGIN_DIR="$HOME/.helm/plugins/registry"
-LATEST=$(latest)
-download_or_noop $LATEST
+download_or_noop
 
 case "$1" in
+  install-plugin)
+    echo "Helm registry plugin installed!"
+    ;;
   upgrade-plugin)
     download_appr "${@:2}"
     ;;

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -9,3 +9,6 @@ description: |-
 ignoreFlags: false
 useTunnel: false
 command: "$HELM_PLUGIN_DIR/cnr.sh"
+hooks:
+    install: "$HELM_PLUGIN_DIR/cnr.sh install-plugin"
+    upgrade: "$HELM_PLUGIN_DIR/cnr.sh upgrade-plugin"


### PR DESCRIPTION
This change adds install and upgrade hooks to the plugin.yaml,
allowing the plugin to be installed with the newer `helm plugin install`
method.

It also removes the call to `latest` in the main script, which speeds up
the plugin quite a bit.